### PR TITLE
Rename wasm32-wasi to wasm32-wasip1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.78.0
+        uses: dtolnay/rust-toolchain@1.79.0
         with:
-          targets: wasm32-wasi
+          targets: wasm32-wasip1
           components: clippy, rustfmt
       - name: cargo fmt
         run: cargo fmt --all -- --check

--- a/test-programs/artifacts/build.rs
+++ b/test-programs/artifacts/build.rs
@@ -14,7 +14,7 @@ fn main() -> Result<()> {
     let status = Command::new("cargo")
         .arg("build")
         .arg("--package=test-programs")
-        .arg("--target=wasm32-wasi")
+        .arg("--target=wasm32-wasip1")
         .env("CARGO_TARGET_DIR", &out_dir)
         .env("CARGO_PROFILE_DEV_DEBUG", "1")
         .status()?;
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
     for target in targets {
         let camel = target.to_shouty_snake_case();
         let wasm = out_dir
-            .join("wasm32-wasi")
+            .join("wasm32-wasip1")
             .join("debug")
             .join(format!("{target}.wasm"));
 


### PR DESCRIPTION
The wasm32-wasi target has been renamed to wasm32-wasip1 and will be deprecated soon.

ref https://github.com/rust-lang/compiler-team/issues/695

After this, we should upgrade [cargo-component](https://github.com/bytecodealliance/cargo-component/pull/313) and update the example to use the wasm32-wasip1 target.