### PR TITLE
Adding authority to Requests for both client and server.

### DIFF
--- a/test-programs/src/bin/client_get_authority.rs
+++ b/test-programs/src/bin/client_get_authority.rs
@@ -1,0 +1,14 @@
+use waki::Client;
+
+fn main() {
+    let req = Client::new()
+        .get("https://httpbin.org/get?a=b")
+        .query(&[("c", "d")])
+        .build()
+        .unwrap();
+
+    match req.authority() {
+        Some(authority) => assert_eq!(authority.as_str(), "httpbin.org"),
+        None => assert!(false, "Authority isn't set on client-request"),
+    }
+}

--- a/test-programs/src/bin/server_authority.rs
+++ b/test-programs/src/bin/server_authority.rs
@@ -1,0 +1,16 @@
+use waki::{handler, ErrorCode, Request, Response};
+
+#[handler]
+fn hello(req: Request) -> Result<Response, ErrorCode> {
+    let authority = req.authority();
+
+    match authority {
+        Some(authority) => Response::builder()
+            .body(format!("Hello, {}!", authority.as_str()))
+            .build(),
+        None => Response::builder().body("Hello!").build(),
+    }
+}
+
+// required since this file is built as a `bin`
+fn main() {}

--- a/waki/src/request.rs
+++ b/waki/src/request.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use anyhow::{anyhow, Error, Result};
 use http::{
-    uri::{Parts, PathAndQuery},
+    uri::{Authority, Parts, PathAndQuery},
     Uri,
 };
 use std::borrow::Borrow;
@@ -199,6 +199,11 @@ impl Request {
             }
             None => HashMap::default(),
         }
+    }
+
+    /// Get the authority of the request.
+    pub fn authority(&self) -> &Option<Authority> {
+        &self.uri.authority
     }
 
     fn send(self) -> Result<Response> {

--- a/waki/tests/all/client.rs
+++ b/waki/tests/all/client.rs
@@ -1,6 +1,13 @@
 use super::run_wasi;
 
 #[tokio::test(flavor = "multi_thread")]
+async fn get_authority() {
+    run_wasi(test_programs_artifacts::CLIENT_GET_AUTHORITY_COMPONENT)
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn get_chunk() {
     run_wasi(test_programs_artifacts::CLIENT_GET_CHUNK_COMPONENT)
         .await

--- a/waki/tests/all/server.rs
+++ b/waki/tests/all/server.rs
@@ -88,6 +88,21 @@ async fn status_code() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn authority() -> Result<()> {
+    let req = hyper::Request::builder()
+        .uri("http://127.0.0.1:3000")
+        .body(body::empty())?;
+
+    let resp: http::Response<http_body_util::Collected<bytes::Bytes>> =
+        run_wasi_http(test_programs_artifacts::SERVER_AUTHORITY_COMPONENT, req).await??;
+    let body = resp.into_body().to_bytes();
+    let body = std::str::from_utf8(&body)?;
+    assert_eq!(body, "Hello, 127.0.0.1:3000!");
+
+    Ok(())
+}
+
 mod body {
     use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full};
     use hyper::{body::Bytes, Error};


### PR DESCRIPTION
Adding authority() to the request struct.
Added tests for server and client.

It is needed for situations when you for example host multiple domains on your server and implements router in your wasm-component.